### PR TITLE
✅ [FEATURE] Pickup rare small one-handed weapons

### DIFF
--- a/src/Pickit/Core/Main.cs
+++ b/src/Pickit/Core/Main.cs
@@ -146,6 +146,9 @@ namespace Pickit.Core
                     Settings.RareArmourilvl.Value = ImGuiExtension.IntSlider("##RareArmours", "Lowest iLvl", Settings.RareArmourilvl);
                     ImGui.SameLine();
                     Settings.RareArmour.Value = ImGuiExtension.Checkbox("Armours", Settings.RareArmour);
+                    Settings.RareWeaponilvl.Value = ImGuiExtension.IntSlider("##RareWeapons", "Lowest iLvl", Settings.RareWeaponilvl);
+                    ImGui.SameLine();
+                    Settings.RareWeapon.Value = ImGuiExtension.Checkbox("Weapons", Settings.RareWeapon);
                     ImGui.TreePop();
                 }
             }
@@ -212,6 +215,7 @@ namespace Pickit.Core
                     if (Settings.RareBoots && item.ClassName == "Boots" && item.ItemLevel >= Settings.RareBootsilvl) return true;
                     if (Settings.RareHelmets && item.ClassName == "Helmet" && item.ItemLevel >= Settings.RareHelmetsilvl) return true;
                     if (Settings.RareArmour && item.ClassName == "Body Armour" && item.ItemLevel >= Settings.RareArmourilvl) return true;
+                    if (Settings.RareWeapon && (item.ClassName == "Dagger" || item.ClassName == "Wand") && item.ItemLevel >= Settings.RareWeaponilvl) return true;
                 }
 
                 #endregion

--- a/src/Pickit/Core/Settings.cs
+++ b/src/Pickit/Core/Settings.cs
@@ -49,6 +49,8 @@ namespace Pickit.Core
             RareHelmetsilvl = new RangeNode<int>(1, 0, 100);
             RareArmour = false;
             RareArmourilvl = new RangeNode<int>(1, 0, 100);
+            RareWeapon = false;
+            RareWeaponilvl = new RangeNode<int>(1, 0, 100);
             PickUpEverything = false;
             NormalRuleFile = string.Empty;
             MagicRuleFile = string.Empty;
@@ -84,6 +86,8 @@ namespace Pickit.Core
         public RangeNode<int> RareHelmetsilvl { get; set; }
         public ToggleNode RareArmour { get; set; }
         public RangeNode<int> RareArmourilvl { get; set; }
+        public ToggleNode RareWeapon { get; set; }
+        public RangeNode<int> RareWeaponilvl { get; set; }
         public EmptyNode LinkSocketRgbEmptyNode { get; set; }
         public ToggleNode Sockets { get; set; }
         public RangeNode<int> TotalSockets { get; set; }


### PR DESCRIPTION
### Main changes ###

- [X] Added configuration for small one-handed rare weapons (iLevel, and toggle)
- [X] The following item classes will be picked up when activated: `dagger`, `wand` (which means `1x3` inventory footprint)